### PR TITLE
Use Go 1.21 finally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.dccache
+

--- a/filter_test.go
+++ b/filter_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"log/slog"
+
 	"github.com/m-mizutani/masq"
-	"golang.org/x/exp/slog"
 )
 
 func newLogger(w io.Writer, f func(groups []string, a slog.Attr) slog.Attr) *slog.Logger {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-mizutani/masq
 
-go 1.20
+go 1.21
 
 require (
 	github.com/m-mizutani/gt v0.0.0-20221229045033-48cc67569435

--- a/masq.go
+++ b/masq.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"regexp"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/masq_test.go
+++ b/masq_test.go
@@ -3,8 +3,9 @@ package masq_test
 import (
 	"os"
 
+	"log/slog"
+
 	"github.com/m-mizutani/masq"
-	"golang.org/x/exp/slog"
 )
 
 type EmailAddr string


### PR DESCRIPTION
- Update Go to 1.21
- Use `log/slog` instead of `golang.org/x/exp/slog`