### PR TITLE
Fix copying of GroupValue

### DIFF
--- a/clone_test.go
+++ b/clone_test.go
@@ -138,7 +138,7 @@ func TestClone(t *testing.T) {
 			gt.V(t, copied.Name).Equal(myType("miss " + masq.DefaultRedactMessage))
 		})
 
-		t.Run("unexported field is not copied", func(t *testing.T) {
+		t.Run("unexported field should be copied", func(t *testing.T) {
 			type myStruct struct {
 				unexported string
 				Exported   string
@@ -149,7 +149,7 @@ func TestClone(t *testing.T) {
 				Exported:   "orange",
 			}
 			copied := gt.MustCast[*myStruct](t, c.Redact(data)).NotNil()
-			gt.V(t, copied.unexported).NotEqual("red")
+			gt.V(t, copied.unexported).Equal("red")
 			gt.V(t, copied.Exported).Equal("orange")
 		})
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -223,3 +223,48 @@ func TestAllowedType(t *testing.T) {
 		t.Errorf("Failed to filter: %s", buf.String())
 	}
 }
+
+type logValuer struct {
+}
+
+func (x logValuer) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("color", "blue"),
+		slog.Any("number", "five"),
+	)
+}
+
+func TestLogValuer(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newLogger(&buf, masq.New())
+
+	var v logValuer
+	logger.Info("test", slog.Any("group", v))
+	t.Log(buf.String())
+	if !strings.Contains(buf.String(), `"color":"blue"`) {
+		t.Errorf("Failed to filter: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"number":"five"`) {
+		t.Errorf("Failed to filter: %s", buf.String())
+	}
+}
+
+func TestArray(t *testing.T) {
+	v := struct {
+		Values [2]string
+	}{
+		Values: [2]string{"blue", "five"},
+	}
+
+	var buf bytes.Buffer
+	logger := newLogger(&buf, masq.New())
+	logger.Info("hello", slog.Any("values", v))
+
+	if !strings.Contains(buf.String(), `"blue"`) {
+		t.Errorf("Failed to filter: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"five"`) {
+		t.Errorf("Failed to filter: %s", buf.String())
+	}
+
+}


### PR DESCRIPTION
# Why

When copying `slog.GroupValue`, the ReplaceAttr function takes in the `slog.Value` structure, which has unexported fields. These fields are necessary to maintain the value of `slog.Value`. Originally, masq avoids copying an unexported field to prevent the exposure of unexpected fields. However, I believe this should be managed in slog.Handler, and ReplaceAttr should not have to worry about whether fields are exported or unexported.

# Changes

- Allow to copy unexported fields in structure
- Separate coping procedure of `reflect.Slice` and `reflect.Array`
- Add tests for `slog.GroupValue`