### PR TITLE
Enhance and simplify clone logic

### DIFF
--- a/clone_test.go
+++ b/clone_test.go
@@ -268,3 +268,21 @@ func TestCloneUnexportedPointer(t *testing.T) {
 	copied := gt.MustCast[*myStruct](t, c.Redact(data)).NotNil()
 	gt.V(t, copied.c.Name).Equal("orange")
 }
+
+func TestDoublePointer(t *testing.T) {
+	c := masq.NewMasq(masq.WithString("blue"))
+	type child struct {
+		Name string
+	}
+	type myStruct struct {
+		c **child
+	}
+	childData := &child{
+		Name: "orange",
+	}
+	data := &myStruct{
+		c: &childData,
+	}
+	copied := gt.MustCast[*myStruct](t, c.Redact(data)).NotNil()
+	gt.V(t, (*copied.c).Name).Equal("orange")
+}

--- a/clone_test.go
+++ b/clone_test.go
@@ -160,15 +160,18 @@ func TestClone(t *testing.T) {
 				Chan      chan int
 				Bool      bool
 				Bytes     []byte
+				Array     [2]string
 				Interface interface{}
 				Child     *child
 			}
 			data := &myStruct{
-				Func:  time.Now,
-				Chan:  make(chan int),
-				Bool:  true,
-				Bytes: []byte("timeless"),
-				Child: nil,
+				Func:      time.Now,
+				Chan:      make(chan int),
+				Bool:      true,
+				Bytes:     []byte("timeless"),
+				Array:     [2]string{"aa", "bb"},
+				Interface: &struct{}{},
+				Child:     nil,
 			}
 			copied := gt.MustCast[*myStruct](t, c.Redact(data)).NotNil()
 
@@ -177,8 +180,9 @@ func TestClone(t *testing.T) {
 			gt.V(t, copied.Chan).Equal(data.Chan)
 			gt.V(t, copied.Bool).Equal(data.Bool)
 			gt.V(t, copied.Bytes).Equal(data.Bytes)
+			gt.V(t, copied.Array).Equal(data.Array)
+			gt.V(t, copied.Interface).Equal(data.Interface)
 		})
-
 	})
 
 	t.Run("filter various type", func(t *testing.T) {
@@ -222,6 +226,45 @@ func TestClone(t *testing.T) {
 		gt.Value(t, copied.StrsPtr).Nil()
 		gt.Value(t, copied.Interface).Nil()
 		gt.Value(t, copied.Child.Data).Equal("")
-		gt.Value(t, copied.ChildPtr.Data).Equal("")
+		gt.Value(t, copied.ChildPtr).Nil()
 	})
+}
+
+func TestMapData(t *testing.T) {
+	c := masq.NewMasq(masq.WithString("blue"))
+
+	type testData struct {
+		ID    int
+		Name  string
+		Label string
+	}
+
+	data := map[string]*testData{
+		"xyz": {
+			Name:  "blue",
+			Label: "five",
+		},
+	}
+	copied := gt.MustCast[map[string]*testData](t, c.Redact(data)).NotNil()
+
+	gt.V(t, copied["xyz"].Name).Equal(masq.DefaultRedactMessage)
+	gt.V(t, copied["xyz"].Label).Equal("five")
+
+}
+
+func TestCloneUnexportedPointer(t *testing.T) {
+	c := masq.NewMasq(masq.WithString("blue"))
+	type child struct {
+		Name string
+	}
+	type myStruct struct {
+		c *child
+	}
+	data := &myStruct{
+		c: &child{
+			Name: "orange",
+		},
+	}
+	copied := gt.MustCast[*myStruct](t, c.Redact(data)).NotNil()
+	gt.V(t, copied.c.Name).Equal("orange")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/m-mizutani/masq
 
 go 1.21
 
-require (
-	github.com/m-mizutani/gt v0.0.0-20221229045033-48cc67569435
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
-)
+require github.com/m-mizutani/gt v0.0.0-20221229045033-48cc67569435
 
 require github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,3 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/m-mizutani/gt v0.0.0-20221229045033-48cc67569435 h1:4EZ4iNhfccquGCmAAGer708a/mrKKVRWGrErPS2c850=
 github.com/m-mizutani/gt v0.0.0-20221229045033-48cc67569435/go.mod h1:0MPYSfGBLmYjTduzADVmIqD58ELQ5IfBFiK/f0FmB3k=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=


### PR DESCRIPTION
# Changes

- Do not use `adjustValue`
- Adjust handling of `reflect.Ptr`
- Now double pointer can be handled properly