### PR TITLE
fix(clone): Creating array by using src.Type directly

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -94,8 +94,7 @@ func (x *masq) clone(fieldName string, src reflect.Value, tag string) reflect.Va
 			return src // can not access to src.Index(0)
 		}
 
-		arrType := reflect.ArrayOf(src.Len(), src.Index(0).Type())
-		dst := reflect.New(arrType).Elem()
+		dst := reflect.New(src.Type()).Elem()
 		for i := 0; i < src.Len(); i++ {
 			dst.Index(i).Set(x.clone(fieldName, src.Index(i), ""))
 		}

--- a/clone_test.go
+++ b/clone_test.go
@@ -289,7 +289,6 @@ func TestTime(t *testing.T) {
 	ts := time.Now()
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
-		AddSource:   true,
 		ReplaceAttr: masq.New(),
 	}))
 	logger.Info("hello")
@@ -300,4 +299,21 @@ func TestTime(t *testing.T) {
 	tv, ok := out["time"].(string)
 	gt.B(t, ok).True()
 	gt.B(t, strings.Contains(tv, ts.Format("2006-01-02"))).True()
+}
+
+type byteType [4]byte
+
+func (x byteType) LogValue() slog.Value { return slog.StringValue("stringer") }
+
+func TestDirectUUID(t *testing.T) {
+	newID := byteType{1, 2, 3, 4}
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: masq.New(),
+	}))
+	logger.Info("hello",
+		slog.Any("id", newID),
+	)
+
+	gt.B(t, strings.Contains(buf.String(), "stringer")).True()
 }


### PR DESCRIPTION
# Why

#10 

# Changes

Use `src.Type()` directly instead of `src.Index(0).Type`