### PR TITLE
Handle interface type properly in clone method

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -106,6 +106,9 @@ func (x *masq) clone(fieldName string, src reflect.Value, tag string) reflect.Va
 		dst.Elem().Set(copied)
 		return dst
 
+	case reflect.Interface:
+		return x.clone(fieldName, src.Elem(), tag)
+
 	default:
 		dst := reflect.New(src.Type())
 		dst.Elem().Set(src)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-mizutani/masq
 
-go 1.21
+go 1.22
 
 require github.com/m-mizutani/gt v0.0.7
 


### PR DESCRIPTION
`reflect.Interface` is no longer handled as `default` type and masq can search in `interface` type also by this fix.