### PR TITLE
Add WithCustomTagKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ logger := slog.New(
             ReplaceAttr: masq.New(
                 // By user defined custom type
                 masq.WithType[AccessToken](),
-        
+
                 // By regex of phone number as e164 format
                 masq.WithRegex(regexp.MustCompile(`^\+[1-9]\d{1,14}$`)),
-        
+
                 // By field tag such as masq:"secret"
                 masq.WithTag("secret"),
-        
+
                 // By by field name prefix. Concealing SecureXxx field
                 masq.WithFieldPrefix("Secure"),
             ),
@@ -166,6 +166,30 @@ logger.With("record", record).Info("Got record")
 out.Flush()
 // Output:
 // {"level":"INFO","msg":"Got record","record":{"EMail":"[FILTERED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+```
+
+You can change the tag key by `masq.WithCustomTagKey` option.
+
+```go
+type myRecord struct {
+    ID    string
+    EMail string `custom:"secret"`
+}
+
+record := myRecord{
+    ID:    "m-mizutani",
+    EMail: "mizutani@hey.com",
+}
+
+logger := newLogger(out, masq.New(
+    masq.WithCustomTagKey("custom"),
+    masq.WithTag("secret"),
+))
+
+logger.With("record", record).Info("Got record")
+out.Flush()
+// Output:
+// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 ```
 
 ### With struct field name

--- a/clone.go
+++ b/clone.go
@@ -84,7 +84,7 @@ func (x *masq) clone(ctx context.Context, fieldName string, src reflect.Value, t
 				srcValue = reflect.NewAt(srcValue.Type(), unsafe.Pointer(srcValue.UnsafeAddr())).Elem()
 			}
 
-			tagValue := f.Tag.Get("masq")
+			tagValue := f.Tag.Get(x.tagKey)
 			copied := x.clone(ctx, f.Name, srcValue, tagValue)
 			dstValue.Set(copied)
 		}

--- a/masq.go
+++ b/masq.go
@@ -8,6 +8,10 @@ import (
 )
 
 const (
+	// DefaultTagKey is a default key name of struct tag for masq. WithCustomTagKey option can change this value.
+	DefaultTagKey = "masq"
+
+	// DefaultRedactMessage is a default message to replace redacted value. WithRedactMessage option can change this value.
 	DefaultRedactMessage = "[REDACTED]"
 )
 
@@ -31,7 +35,7 @@ func newMasq(options ...Option) *masq {
 	m := &masq{
 		redactMessage: DefaultRedactMessage,
 		allowedTypes:  map[reflect.Type]struct{}{},
-		tagKey:        "masq",
+		tagKey:        DefaultTagKey,
 	}
 	m.defaultRedactor = func(src, dst reflect.Value) bool {
 		switch src.Kind() {

--- a/masq.go
+++ b/masq.go
@@ -17,6 +17,7 @@ type masq struct {
 	allowedTypes  map[reflect.Type]struct{}
 
 	defaultRedactor Redactor
+	tagKey          string
 }
 
 type Filter struct {
@@ -30,6 +31,7 @@ func newMasq(options ...Option) *masq {
 	m := &masq{
 		redactMessage: DefaultRedactMessage,
 		allowedTypes:  map[reflect.Type]struct{}{},
+		tagKey:        "masq",
 	}
 	m.defaultRedactor = func(src, dst reflect.Value) bool {
 		switch src.Kind() {

--- a/options.go
+++ b/options.go
@@ -35,8 +35,12 @@ func WithTag(tag string, redactors ...Redactor) Option {
 	return WithCensor(newTagCensor(tag), redactors...)
 }
 
-// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`.
+// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
 func WithCustomTagKey(tagKey string) Option {
+	if tagKey == "" {
+		panic("masq: tag key must not be empty")
+	}
+
 	return func(m *masq) {
 		m.tagKey = tagKey
 	}

--- a/options.go
+++ b/options.go
@@ -35,6 +35,13 @@ func WithTag(tag string, redactors ...Redactor) Option {
 	return WithCensor(newTagCensor(tag), redactors...)
 }
 
+// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`.
+func WithCustomTagKey(tagKey string) Option {
+	return func(m *masq) {
+		m.tagKey = tagKey
+	}
+}
+
 // WithFieldName is an option to check if the field name is matched with the target field name. If the field name is the target field name, the field will be redacted.
 func WithFieldName(fieldName string, redactors ...Redactor) Option {
 	return WithCensor(newFieldNameCensor(fieldName), redactors...)

--- a/options_test.go
+++ b/options_test.go
@@ -149,6 +149,16 @@ func ExampleWithCustomTagKey() {
 	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 }
 
+func TestCustomTagKeyPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Errorf("Failed to panic")
+		}
+	}()
+
+	masq.New(masq.WithCustomTagKey(""))
+}
+
 func ExampleWithFieldName() {
 	out := &fixedTimeWriter{}
 

--- a/options_test.go
+++ b/options_test.go
@@ -125,6 +125,30 @@ func ExampleWithTag() {
 	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 }
 
+func ExampleWithCustomTagKey() {
+	out := &fixedTimeWriter{}
+
+	type myRecord struct {
+		ID    string
+		EMail string `custom:"secret"`
+	}
+
+	record := myRecord{
+		ID:    "m-mizutani",
+		EMail: "mizutani@hey.com",
+	}
+
+	logger := newLogger(out, masq.New(
+		masq.WithCustomTagKey("custom"),
+		masq.WithTag("secret"),
+	))
+
+	logger.With("record", record).Info("Got record")
+	out.Flush()
+	// Output:
+	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+}
+
 func ExampleWithFieldName() {
 	out := &fixedTimeWriter{}
 


### PR DESCRIPTION
This pull request introduces a new feature that allows setting a custom tag key for the `masq` struct. This enhancement provides more flexibility in defining and using tags for redaction.

Key changes include:

### New Feature: Custom Tag Key

* Added a new field `tagKey` to the `masq` struct to store the custom tag key. (`masq.go`)
* Updated the `newMasq` function to initialize the `tagKey` with a default value of "masq". (`masq.go`)
* Modified the `clone` method to use the custom tag key instead of the hardcoded "masq" tag. (`clone.go`)
* Introduced a new option `WithCustomTagKey` to allow users to set a custom tag key when creating a new `masq` instance. (`options.go`)
* Added a test example `ExampleWithCustomTagKey` to demonstrate how to use the new `WithCustomTagKey` option. (`options_test.go`)

### Example

```go
	type myRecord struct {
		ID    string
		EMail string `custom:"secret"`
	}

	record := myRecord{
		ID:    "m-mizutani",
		EMail: "mizutani@hey.com",
	}

	logger := newLogger(out, masq.New(
		masq.WithCustomTagKey("custom"),
		masq.WithTag("secret"),
	))

	logger.With("record", record).Info("Got record")
	out.Flush()
	// Output:
	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
```