### PR TITLE
fix(action): trivy failure

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,26 +1,38 @@
-name: Vulnerability scan
+name: trivy
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
 
     steps:
       - name: Checkout upstream repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.head_ref }}
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+      - id: scan
+        name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@f3d98514b056d8c71a3552e8328c225bc7f6f353 # master
         with:
           scan-type: "fs"
           ignore-unfixed: true
-          format: "template"
-          template: "@/contrib/sarif.tpl"
+          format: "sarif"
           output: "trivy-results.sarif"
+          exit-code: 1
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        if: failure() && steps.scan.outcome == 'failure'
+        uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
This pull request updates the `.github/workflows/trivy.yml` file to enhance the Trivy vulnerability scanning workflow. The key changes include renaming the workflow, modifying the trigger events, updating the permissions, and refining the steps for running and uploading the scan results.

Workflow updates:

* Renamed the workflow from "Vulnerability scan" to "trivy".
* Modified the trigger events to include `push`, a scheduled cron job, and `workflow_dispatch`.

Permissions and steps updates:

* Added specific permissions for `security-events`, `actions`, and `contents`.
* Updated the `actions/checkout` and `aquasecurity/trivy-action` to specific commit references for better stability.
* Changed the Trivy scan output format to `sarif` and added `TRIVY_DB_REPOSITORY` environment variable.
* Added a conditional step to upload Trivy scan results to GitHub Security tab only if the scan fails.