### PR TITLE
Add support for WithTagKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,36 @@ out.Flush()
 // {"level":"INFO","msg":"Got record","record":{"ID":"m-mizutani","SecurePhone":"[FILTERED]"},"time":"2022-12-25T09:00:00.123456789"}
 ```
 
+### With struct field tag (with custom tag key)
+
+```go
+type myRecord struct {
+    ID    string
+    EMail string `piifield:"secret"`
+}
+record := myRecord{
+    ID:    "m-mizutani",
+    EMail: "mizutani@hey.com",
+}
+
+logger := slog.New(
+    slog.NewJSONHandler(
+        os.Stdout,
+        &slog.HandlerOptions{
+            ReplaceAttr: masq.New(
+                masq.WithTag("secret"),
+                masq.WithTagKey("piifielld"),
+            ),
+        },
+    ),
+)
+
+logger.With("record", record).Info("Got record")
+out.Flush()
+// Output:
+// {"level":"INFO","msg":"Got record","record":{"EMail":"[FILTERED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+```
+
 ## License
 
 Apache License v2.0

--- a/clone.go
+++ b/clone.go
@@ -84,7 +84,7 @@ func (x *masq) clone(ctx context.Context, fieldName string, src reflect.Value, t
 				srcValue = reflect.NewAt(srcValue.Type(), unsafe.Pointer(srcValue.UnsafeAddr())).Elem()
 			}
 
-			tagValue := f.Tag.Get("masq")
+			tagValue := f.Tag.Get(x.tagKey)
 			copied := x.clone(ctx, f.Name, srcValue, tagValue)
 			dstValue.Set(copied)
 		}

--- a/masq.go
+++ b/masq.go
@@ -9,10 +9,12 @@ import (
 
 const (
 	DefaultRedactMessage = "[REDACTED]"
+	DefaultTagKey        = "masq"
 )
 
 type masq struct {
 	redactMessage string
+	tagKey        string
 	filters       []*Filter
 	allowedTypes  map[reflect.Type]struct{}
 

--- a/options.go
+++ b/options.go
@@ -60,3 +60,14 @@ func WithRedactMessage(message string) Option {
 		m.redactMessage = message
 	}
 }
+
+// WithTagKey gives option to change the default
+// tag key to a custom tag key
+func WithTagKey(key string) Option {
+	return func(m *masq) {
+		if key == "" {
+			m.tagKey = DefaultTagKey
+		}
+		m.tagKey = key
+	}
+}


### PR DESCRIPTION
Add support for WithTagKey()

Fixes https://github.com/m-mizutani/masq/issues/18

```go
type myRecord struct {
    ID    string
    EMail string `piifield:"secret"`
}
record := myRecord{
    ID:    "m-mizutani",
    EMail: "mizutani@hey.com",
}

logger := slog.New(
    slog.NewJSONHandler(
        os.Stdout,
        &slog.HandlerOptions{
            ReplaceAttr: masq.New(
                masq.WithTag("secret"),
                masq.WithTagKey("piifielld"),
            ),
        },
    ),
)

logger.With("record", record).Info("Got record")
out.Flush()
// Output:
// {"level":"INFO","msg":"Got record","record":{"EMail":"[FILTERED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
```