### PR TITLE
fix(clone): Ignore `reflect.rtype`

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -58,6 +58,7 @@ func (x *masq) clone(ctx context.Context, fieldName string, src reflect.Value, t
 
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
+			println("f.Name", f.Name)
 			srcValue := src.Field(i)
 			dstValue := dst.Elem().Field(i)
 
@@ -82,6 +83,10 @@ func (x *masq) clone(ctx context.Context, fieldName string, src reflect.Value, t
 				}
 
 				srcValue = reflect.NewAt(srcValue.Type(), unsafe.Pointer(srcValue.UnsafeAddr())).Elem()
+			} else if srcValue.Kind() == reflect.Func {
+				println("func!")
+				dstValue.Set(srcValue)
+				continue
 			}
 
 			tagValue := f.Tag.Get(x.tagKey)

--- a/clone_test.go
+++ b/clone_test.go
@@ -343,3 +343,17 @@ func TestCircularReference(t *testing.T) {
 	newData := c.Redact(data).(*myStruct)
 	gt.V(t, newData.Child.Child.Str).Equal("[REDACTED]")
 }
+
+func TestCloneJsonUnmarshalTypeError(t *testing.T) {
+	var s string
+	src := json.Unmarshal([]byte(`["foo"]`), &s).(*json.UnmarshalTypeError)
+	dst := masq.NewMasq().Redact(src).(*json.UnmarshalTypeError)
+	gt.Equal(t, dst, src)
+}
+
+func TestCloneFunc(t *testing.T) {
+	type myFunc func() string
+	src := myFunc(func() string { return "blue" })
+	dst := masq.NewMasq().Redact(src).(myFunc)
+	gt.Equal(t, dst(), "blue")
+}

--- a/clone_test.go
+++ b/clone_test.go
@@ -344,16 +344,20 @@ func TestCircularReference(t *testing.T) {
 	gt.V(t, newData.Child.Child.Str).Equal("[REDACTED]")
 }
 
-func TestCloneJsonUnmarshalTypeError(t *testing.T) {
-	var s string
-	src := json.Unmarshal([]byte(`["foo"]`), &s).(*json.UnmarshalTypeError)
-	dst := masq.NewMasq().Redact(src).(*json.UnmarshalTypeError)
-	gt.Equal(t, dst, src)
-}
-
 func TestCloneFunc(t *testing.T) {
 	type myFunc func() string
 	src := myFunc(func() string { return "blue" })
 	dst := masq.NewMasq().Redact(src).(myFunc)
 	gt.Equal(t, dst(), "blue")
+}
+
+func TestUnmarshalTypeError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: masq.New(),
+	}))
+	var s string
+	err := json.Unmarshal([]byte(`["foo"]`), &s)
+	logger.Info("error", slog.Any("err", err))
+	gt.S(t, buf.String()).Contains("error")
 }

--- a/masq_test.go
+++ b/masq_test.go
@@ -1,10 +1,7 @@
 package masq_test
 
 import (
-	"encoding/json"
 	"os"
-	"reflect"
-	"testing"
 
 	"log/slog"
 
@@ -27,20 +24,4 @@ func Example() {
 	}))
 
 	logger.Info("hello", slog.Any("user", u))
-}
-
-func TestJsonUnmarshalTypeError(t *testing.T) {
-	// It should not panic
-	logger := slog.New(
-		slog.NewJSONHandler(
-			os.Stdout,
-			&slog.HandlerOptions{
-				ReplaceAttr: masq.New(masq.WithAllowedType(reflect.TypeOf(json.UnmarshalTypeError{}))),
-			},
-		),
-	)
-	var s string
-	err := json.Unmarshal([]byte(`["foo"]`), &s)
-	slog.Info("error", "err", err)
-	logger.Info("error", "err", err)
 }

--- a/masq_test.go
+++ b/masq_test.go
@@ -1,7 +1,10 @@
 package masq_test
 
 import (
+	"encoding/json"
 	"os"
+	"reflect"
+	"testing"
 
 	"log/slog"
 
@@ -24,4 +27,20 @@ func Example() {
 	}))
 
 	logger.Info("hello", slog.Any("user", u))
+}
+
+func TestJsonUnmarshalTypeError(t *testing.T) {
+	// It should not panic
+	logger := slog.New(
+		slog.NewJSONHandler(
+			os.Stdout,
+			&slog.HandlerOptions{
+				ReplaceAttr: masq.New(masq.WithAllowedType(reflect.TypeOf(json.UnmarshalTypeError{}))),
+			},
+		),
+	)
+	var s string
+	err := json.Unmarshal([]byte(`["foo"]`), &s)
+	slog.Info("error", "err", err)
+	logger.Info("error", "err", err)
 }


### PR DESCRIPTION
Original issue: https://github.com/m-mizutani/masq/issues/23
This pull request introduces changes to the `clone.go` and `clone_test.go` files to enhance the handling of certain types and add new test cases. The key changes involve the introduction of a map to ignore specific types during cloning operations and the addition of new test functions.

### Enhancements in type handling:

* [`clone.go`](diffhunk://#diff-a88eb3d6d4c76e9df7a5726922853d46472469dc6b1a18b6128ade0f5a118c0aR15-R21): Added a new `ignoreTypes` map to list types that should not be redacted, such as `*reflect.rtype`, to prevent panics caused by copying certain types.
* [`clone.go`](diffhunk://#diff-a88eb3d6d4c76e9df7a5726922853d46472469dc6b1a18b6128ade0f5a118c0aR36-R38): Modified the `clone` function to check against the `ignoreTypes` map and return the source value if it matches an ignored type.

### Additions to test coverage:

* [`clone_test.go`](diffhunk://#diff-f4bed2e5a02f2b028eb5f26bd5b0196a39c4a3d6a3c3323f1f21fe88e26d5cc3R346-R363): Added a new test function `TestCloneFunc` to verify that functions are correctly cloned without modification.
* [`clone_test.go`](diffhunk://#diff-f4bed2e5a02f2b028eb5f26bd5b0196a39c4a3d6a3c3323f1f21fe88e26d5cc3R346-R363): Added a new test function `TestUnmarshalTypeError` to ensure that JSON unmarshalling errors are correctly logged and handled.