### PR TITLE
Add support for multiple tags and tag operations

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -8,12 +8,12 @@ import (
 
 // Censor is a function to check if the field should be redacted. It receives field name, value, and tag of struct if the value is in struct.
 // If the field should be redacted, it returns true.
-type Censor func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool
+type Censor func(fieldName string, value any, tags map[string]Tag) bool
 type Censors []Censor
 
-func (x Censors) ShouldRedact(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+func (x Censors) ShouldRedact(fieldName string, value any, tags map[string]Tag) bool {
 	for _, censor := range x {
-		if censor(fieldName, value, tags, masqTagKey) {
+		if censor(fieldName, value, tags) {
 			return true
 		}
 	}
@@ -22,7 +22,7 @@ func (x Censors) ShouldRedact(fieldName string, value any, tags map[string]Tag, 
 
 // string
 func newStringCensor(target string) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		v := reflect.ValueOf(value)
 		if v.Kind() != reflect.String {
 			return false
@@ -34,7 +34,7 @@ func newStringCensor(target string) Censor {
 
 // regex
 func newRegexCensor(target *regexp.Regexp) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		v := reflect.ValueOf(value)
 		if v.Kind() != reflect.String {
 			return false
@@ -46,7 +46,7 @@ func newRegexCensor(target *regexp.Regexp) Censor {
 
 // type
 func newTypeCensor[T any]() Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		var v T
 		return reflect.TypeOf(v) == reflect.TypeOf(value)
 	}
@@ -54,8 +54,8 @@ func newTypeCensor[T any]() Censor {
 
 // tag
 func newTagCensor(tagValue string) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
-		tag, ok := tags[masqTagKey]
+	return func(fieldName string, value any, tags map[string]Tag) bool {
+		tag, ok := tags[masqTagMapKey]
 		if !ok {
 			return false
 		}
@@ -64,7 +64,7 @@ func newTagCensor(tagValue string) Censor {
 }
 
 func newTagMatchCensor(tagKey string, matchFn func(tagValue string) bool) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		tag, ok := tags[tagKey]
 		if !ok {
 			return false
@@ -93,14 +93,14 @@ func newTagKeyValueContainsCensor(tagKey string, targetValue string) Censor {
 
 // field name
 func newFieldNameCensor(name string) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		return name == fieldName
 	}
 }
 
 // field name prefix
 func newFieldPrefixCensor(prefix string) Censor {
-	return func(fieldName string, value any, tags map[string]Tag, masqTagKey string) bool {
+	return func(fieldName string, value any, tags map[string]Tag) bool {
 		return strings.HasPrefix(fieldName, prefix)
 	}
 }

--- a/clone_test.go
+++ b/clone_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/m-mizutani/masq"
 )
 
-func allFieldCensor(fieldName string, value interface{}, tags map[string]masq.Tag, masqTagKey string) bool {
+func allFieldCensor(fieldName string, value interface{}, tags map[string]masq.Tag) bool {
 	return fieldName != ""
 }
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/m-mizutani/masq"
 )
 
-func allFieldCensor(fieldName string, value interface{}, tag string) bool {
+func allFieldCensor(fieldName string, value interface{}, tags map[string]masq.Tag, masqTagKey string) bool {
 	return fieldName != ""
 }
 

--- a/masq.go
+++ b/masq.go
@@ -21,12 +21,18 @@ type masq struct {
 	allowedTypes  map[reflect.Type]struct{}
 
 	defaultRedactor Redactor
-	tagKey          string
+	masqTagKey      string
+	tagKeys         map[string]struct{}
 }
 
 type Filter struct {
 	censor    Censor
 	redactors Redactors
+}
+
+type Tag struct {
+	Key   string
+	Value string
 }
 
 type Option func(m *masq)
@@ -35,7 +41,8 @@ func newMasq(options ...Option) *masq {
 	m := &masq{
 		redactMessage: DefaultRedactMessage,
 		allowedTypes:  map[reflect.Type]struct{}{},
-		tagKey:        DefaultTagKey,
+		masqTagKey:    DefaultTagKey,
+		tagKeys:       map[string]struct{}{},
 	}
 	m.defaultRedactor = func(src, dst reflect.Value) bool {
 		switch src.Kind() {
@@ -58,7 +65,7 @@ func (x *masq) redact(k string, v any) any {
 	}
 
 	ctx := context.Background()
-	copied := x.clone(ctx, k, reflect.ValueOf(v), "")
+	copied := x.clone(ctx, k, reflect.ValueOf(v), nil)
 	return copied.Interface()
 }
 

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 // WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
 func WithCustomTagKey(tagKey string) Option {
 	if tagKey == "" {
-		panic("masq:tagKey is empty")
+		panic("masq: tag key must not be empty")
 	}
 	return func(m *masq) {
 		m.masqTagKey = tagKey

--- a/options.go
+++ b/options.go
@@ -35,11 +35,10 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 	return WithCensor(newTagCensor(tagValue), redactors...)
 }
 
-
-// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
-func WithCustomTagKey(tagKey string) Option {
+// WithCustomTagKey is an option to set the custom tag key. If the tag key is empty, it panics.
+func WithCustomTagKey(tagKey string, redactors ...Redactor) Option {
 	if tagKey == "" {
-		panic("masq: tag key must not be empty")
+		panic("masq:tagKey is empty")
 	}
 	return func(m *masq) {
 		m.masqTagKey = tagKey

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 // WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
 func WithCustomTagKey(tagKey string) Option {
 	if tagKey == "" {
-		panic("masq: tag must not be empty")
+		panic("masq: tag key must not be empty")
 	}
 	return func(m *masq) {
 		m.masqTagKey = tagKey

--- a/options.go
+++ b/options.go
@@ -35,10 +35,11 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 	return WithCensor(newTagCensor(tagValue), redactors...)
 }
 
-// WithCustomTagKey is an option to set the custom tag key. If the tag key is empty, it panics.
-func WithCustomTagKey(tagKey string, redactors ...Redactor) Option {
+
+// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
+func WithCustomTagKey(tagKey string) Option {
 	if tagKey == "" {
-		panic("masq:tagKey is empty")
+		panic("masq:tagKey must not be empty")
 	}
 	return func(m *masq) {
 		m.masqTagKey = tagKey

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 // WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
 func WithCustomTagKey(tagKey string) Option {
 	if tagKey == "" {
-		panic("masq:tagKey must not be empty")
+		panic("masq: tag must not be empty")
 	}
 	return func(m *masq) {
 		m.masqTagKey = tagKey

--- a/options.go
+++ b/options.go
@@ -35,8 +35,9 @@ func WithTag(tagValue string, redactors ...Redactor) Option {
 	return WithCensor(newTagCensor(tagValue), redactors...)
 }
 
-// WithCustomTagKey is an option to set the custom tag key. If the tag key is empty, it panics.
-func WithCustomTagKey(tagKey string, redactors ...Redactor) Option {
+
+// WithCustomTagKey is an option to set the custom tag key. The default tag key is `masq`. If the field has the target tag in the custom tag key AND the field is matched with the target tag specified by WithTag, the field will be redacted. If tagKey is empty, WithCustomTagKey panics.
+func WithCustomTagKey(tagKey string) Option {
 	if tagKey == "" {
 		panic("masq:tagKey is empty")
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -193,6 +193,52 @@ func ExampleWithTagKeyValueWithRegex() {
 	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 }
 
+func ExampleWithTagKeyValueContains() {
+	out := &fixedTimeWriter{}
+
+	type myRecord struct {
+		ID    string
+		EMail string `foo:"bar,baz"`
+	}
+	record := myRecord{
+		ID:    "m-mizutani",
+		EMail: "mizutani@hey.com",
+	}
+
+	logger := newLogger(out, masq.New(
+		masq.WithTagKeyValueContains("foo", "bar"),
+	))
+
+	logger.With("record", record).Info("Got record")
+	out.Flush()
+	// Output:
+	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+}
+
+func ExampleWithTagKeyValueMatch() {
+	out := &fixedTimeWriter{}
+
+	type myRecord struct {
+		ID    string
+		EMail string `foo:"bar,baz"`
+	}
+	record := myRecord{
+		ID:    "m-mizutani",
+		EMail: "mizutani@hey.com",
+	}
+
+	logger := newLogger(out, masq.New(
+		masq.WithTagKeyValueMatch("foo", func (tagValue string) bool {
+			return tagValue == "bar,baz"
+		}),
+	))
+
+	logger.With("record", record).Info("Got record")
+	out.Flush()
+	// Output:
+	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+}
+
 func TestCustomTagKeyPanic(t *testing.T) {
 	defer func() {
 		if recover() == nil {

--- a/options_test.go
+++ b/options_test.go
@@ -193,52 +193,6 @@ func ExampleWithTagKeyValueWithRegex() {
 	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 }
 
-func ExampleWithTagKeyValueContains() {
-	out := &fixedTimeWriter{}
-
-	type myRecord struct {
-		ID    string
-		EMail string `foo:"bar,baz"`
-	}
-	record := myRecord{
-		ID:    "m-mizutani",
-		EMail: "mizutani@hey.com",
-	}
-
-	logger := newLogger(out, masq.New(
-		masq.WithTagKeyValueContains("foo", "bar"),
-	))
-
-	logger.With("record", record).Info("Got record")
-	out.Flush()
-	// Output:
-	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
-}
-
-func ExampleWithTagKeyValueMatch() {
-	out := &fixedTimeWriter{}
-
-	type myRecord struct {
-		ID    string
-		EMail string `foo:"bar,baz"`
-	}
-	record := myRecord{
-		ID:    "m-mizutani",
-		EMail: "mizutani@hey.com",
-	}
-
-	logger := newLogger(out, masq.New(
-		masq.WithTagKeyValueMatch("foo", func (tagValue string) bool {
-			return tagValue == "bar,baz"
-		}),
-	))
-
-	logger.With("record", record).Info("Got record")
-	out.Flush()
-	// Output:
-	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
-}
-
 func TestCustomTagKeyPanic(t *testing.T) {
 	defer func() {
 		if recover() == nil {

--- a/options_test.go
+++ b/options_test.go
@@ -149,6 +149,50 @@ func ExampleWithCustomTagKey() {
 	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
 }
 
+func ExampleWithTagKeyValue() {
+	out := &fixedTimeWriter{}
+
+	type myRecord struct {
+		ID    string
+		EMail string `foo:"bar"`
+	}
+	record := myRecord{
+		ID:    "m-mizutani",
+		EMail: "mizutani@hey.com",
+	}
+
+	logger := newLogger(out, masq.New(
+		masq.WithTagKeyValue("foo", "bar"),
+	))
+
+	logger.With("record", record).Info("Got record")
+	out.Flush()
+	// Output:
+	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+}
+
+func ExampleWithTagKeyValueWithRegex() {
+	out := &fixedTimeWriter{}
+
+	type myRecord struct {
+		ID    string
+		EMail string `foo:"bar,baz"`
+	}
+	record := myRecord{
+		ID:    "m-mizutani",
+		EMail: "mizutani@hey.com",
+	}
+
+	logger := newLogger(out, masq.New(
+		masq.WithTagKeyValueWithRegex("foo", regexp.MustCompile(`^bar`)),
+	))
+
+	logger.With("record", record).Info("Got record")
+	out.Flush()
+	// Output:
+	// {"level":"INFO","msg":"Got record","record":{"EMail":"[REDACTED]","ID":"m-mizutani"},"time":"2022-12-25T09:00:00.123456789"}
+}
+
 func TestCustomTagKeyPanic(t *testing.T) {
 	defer func() {
 		if recover() == nil {


### PR DESCRIPTION
### Motivating use-case

I have a project where redacting based on JSON tags would greatly simplify the log sanitation config. Additionally, the current implementation only allows for redaction based on a single tag, and it's easy to imagine additional use-cases for matching on additional struct tags

```go
type SystemAGeo struct {
	Latitude  float64 `json:"lat"`
	Longitude float64 `json:"lng"`
}

type SystemBGeo struct {
	X float64 `json:"lat"`
	Y float64 `json:"lng"`
}

func main() {
	// ...
	slog.NewJSONHandler(
		os.Stdout,
		&slog.HandlerOptions{
			ReplaceAttr: masq.New(
				masq.WithTagKeyValueContains("json", "lat"),
				masq.WithTagKeyValueContains("json", "lng"),
			),
		},
	)
	// ...
}
```