### PR TITLE
ci: integrate cicd-sensor across all workflows

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout Source
         uses: actions/checkout@v3
       - name: Run Gosec Security Scanner

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
## Summary

- Add [cicd-sensor-action](https://github.com/cicd-sensor/cicd-sensor-action) (eBPF-based runtime security sensor for CI/CD) as the first step in every workflow: `test.yml`, `lint.yml`, `gosec.yml`, `trivy.yml`
- Pinned by commit SHA (`6ee257338e68af2b279b321b3346fe5f385aa498`, v0.0.29) with the tag in a trailing comment, per supply-chain best practice for third-party Actions

## Why

The action monitors process ancestry on the runner via eBPF and surfaces suspicious patterns (e.g. credential access during dependency install). Wiring it into every workflow gives consistent telemetry across all CI surfaces.

## Notes

- The org `cicd-sensor` is recently founded (2026-05). Pinning by SHA keeps the version immutable; bumps will be deliberate.
- Self-hosted runners are not used here, so no extra setup is required beyond adding the step.

## Test plan

- [ ] Verify the action runs on `ubuntu-latest` for all 4 workflows without breaking existing steps
- [ ] Confirm job summaries / artifacts from cicd-sensor render as expected
- [ ] No regressions in test, lint, gosec, trivy jobs